### PR TITLE
Update boards gracefully when groups are found

### DIFF
--- a/src/components/GameStateProvider/GameStateProvider.tsx
+++ b/src/components/GameStateProvider/GameStateProvider.tsx
@@ -1,25 +1,33 @@
 import { createContext, ReactNode, useEffect } from "react";
 import { useState } from "react";
 import { CardType } from "../Card/cardTypes";
-import { CARDS_PER_GROUP, DEFAULT_DECK, DEFAULT_GAME_STATE, DEFAULT_MODE, InvalidCard } from "./gameConstants";
+import { DEFAULT_DECK, DEFAULT_GAME_STATE, InvalidCard, Mode, MODE_SETTINGS, Orientation } from "./gameConstants";
 import { addAttribute, getCard, removeCards, shuffleDeck, validateGroup } from "./gameHelpers";
 
 export const GameStateContext = createContext(DEFAULT_GAME_STATE);
 
 export function GameStateProvider({ children }: { children: ReactNode }) {
+  const [currentGroup, setCurrentGroup] = useState<CardType[]>([]);
+  const [invalidGroup, setInvalidGroup] = useState<InvalidCard[]>([]);
+  const [mode, setMode] = useState<Mode>(Mode.Set);
+  const [orientation, setOrientation] = useState<Orientation>(Orientation.Vertical);
+  const [invalidDelay, setInvalidDelay] = useState<number>(2.5);
+  const [numAttributes, setNumAttributes] = useState<number>(4);
   const [deck, setDeck] = useState<CardType[]>(() => {
     const baseDeck = DEFAULT_DECK;
-    const tempDeck = addAttribute(3, baseDeck);
+    const tempDeck = addAttribute(numAttributes - 1, baseDeck);
     // make the type checker happy since addAttribute is recursive
     if (tempDeck === undefined) return baseDeck;
     shuffleDeck(tempDeck);
     return tempDeck;
   });
-  const [currentGroup, setCurrentGroup] = useState<CardType[]>([]);
-  const [invalidGroup, setInvalidGroup] = useState<InvalidCard[]>([]);
-  const [mode, setMode] = useState<string>(DEFAULT_MODE);
+  const [boardSize, setBoardSize] = useState<number>(() => {
+    return MODE_SETTINGS[mode].boardSize;
+  });
 
   function handleCardClick(card: CardType) {
+    const cardsPerGroup = MODE_SETTINGS[mode].groupSize;
+
     // Since we instantly remove any card you click on twice, we don't have to
     // worry about any case of potentially adding the same card 3x in the
     // validation function. Hooray!
@@ -34,13 +42,12 @@ export function GameStateProvider({ children }: { children: ReactNode }) {
     const newCurrentGroup = [...currentGroup, card];
 
     // Don't remove from deck yet, we'll do that when we complete a group
-    if (newCurrentGroup.length <= CARDS_PER_GROUP[mode as keyof typeof CARDS_PER_GROUP] - 1) {
+    if (newCurrentGroup.length <= cardsPerGroup - 1) {
       setCurrentGroup(newCurrentGroup);
       return;
     }
     if (validateGroup(newCurrentGroup)) {
-      const tempDeck = [...deck];
-      const newDeck = removeCards(tempDeck, newCurrentGroup);
+      const newDeck = removeCards(deck, newCurrentGroup, boardSize, cardsPerGroup);
       setCurrentGroup([]);
       setDeck(newDeck);
     } else {
@@ -55,7 +62,7 @@ export function GameStateProvider({ children }: { children: ReactNode }) {
                     return ic.card.id !== c.id;
                   });
                 });
-              }, 2500);
+              }, invalidDelay * 1000);
             },
           };
         })

--- a/src/components/GameStateProvider/gameConstants.ts
+++ b/src/components/GameStateProvider/gameConstants.ts
@@ -21,13 +21,27 @@ export const DEFAULT_DECK = [
 ];
 
 export interface InvalidCard {
-    card: CardType;
-    destroy: Function;
+  card: CardType;
+  destroy: Function;
 }
 
-export const CARDS_PER_GROUP = {
-    set: 3,
-    planet: 4,
+export enum Mode {
+  Set = 0,
+  Planet = 1,
 }
 
-export const DEFAULT_MODE = "set";
+export enum Orientation {
+  Vertical = 0,
+  Horizontal = 1,
+}
+
+export const MODE_SETTINGS = {
+  [Mode.Set]: {
+    groupSize: 3,
+    boardSize: 12,
+  },
+  [Mode.Planet]: {
+    groupSize: 4,
+    boardSize: 12,
+  },
+};

--- a/src/components/GameStateProvider/gameHelpers.ts
+++ b/src/components/GameStateProvider/gameHelpers.ts
@@ -1,4 +1,4 @@
-import { range } from "lodash";
+import { range, toNumber } from "lodash";
 import { getRandomInt } from "../../utils";
 import { CardType } from "../Card/cardTypes";
 
@@ -43,11 +43,31 @@ export function getCard(deck: CardType[], id: string): CardType | undefined {
   return undefined;
 }
 
+export function removeCards(deck: CardType[], matchedGroup: CardType[], boardSize: number, groupSize: number) {
+  const newDeck = [];
+  let j = 0;
+  for (let i in deck) {
+    let card = deck[i];
+    if (toNumber(i) >= boardSize + groupSize) {
+      newDeck.push(card);
+    } else if (toNumber(i) >= boardSize) {
+      continue;
+    } else if (!matchedGroup.includes(card)) {
+      newDeck.push(card);
+    } else {
+      // TODO: Handle end of game gracefully here
+      newDeck.push(deck[boardSize + j]);
+      j++;
+    }
+  }
+  return newDeck;
+}
+
+// prettier-ignore
 export function validateGroup(possibleGroup: CardType[]) {
   let isValid = true;
   for (let i in possibleGroup[0].vector) {
     // in which I write the entire game in 1 line of code
-    // prettier-ignore
     if (
       possibleGroup.reduce((sum, card) => {
         return sum + card.vector[i];
@@ -57,11 +77,4 @@ export function validateGroup(possibleGroup: CardType[]) {
     }
   }
   return isValid;
-}
-
-export function removeCards(deck: CardType[], matchedGroup: CardType[]) {
-  const newDeck = [...deck];
-  return newDeck.filter((card) => {
-    return !matchedGroup.includes(card);
-  });
 }


### PR DESCRIPTION
This addresses:

2\. The board SHUFFLES every time a set is claimed, instead of the cards falling gracefully into place from #4 